### PR TITLE
Include PUT parameters in OAuth signature

### DIFF
--- a/content/restclient.js
+++ b/content/restclient.js
@@ -164,7 +164,7 @@ var restclient = {
     parameters.oauth_timestamp = passwordObject.autoTimestamp ? null : passwordObject.timestamp;
     
     // if the content-type is form-encoded, we need to add it to the parameters
-    if (message.method == "POST" && this.isContentTypeFormUrlEncoded()) {
+    if ((message.method == "POST" || message.method == "PUT") && this.isContentTypeFormUrlEncoded()) {
       var formParams = OAuth.decodeForm($('tbRequestBody').value);
       for(var i in formParams)
       {


### PR DESCRIPTION
Previously only POST requests were included.
