### PR TITLE
Change to handle a body of zero length

### DIFF
--- a/content/js/restclient.http.js
+++ b/content/js/restclient.http.js
@@ -134,6 +134,11 @@ restclient.http = {
       }
     }
     
+    // handle a zero length body
+    if(xhr.responseText.length == 0) {
+      displayHandler = 'displayImageRaw';
+    }
+    
     //restclient.log(displayHandler);
     //restclient.log(contentType);
     restclient.main.checkMimeType.apply(restclient.http, []);


### PR DESCRIPTION
If a 204 response with a Content-type is returned, then the parsers fail. This change uses the displayImageRaw displayHandler if there is no body.