### PR TITLE
Replace -moz-calc() with calc() for Firefox 53+ compatibility

### DIFF
--- a/content/restclient.html
+++ b/content/restclient.html
@@ -113,7 +113,7 @@
           </ul>
         </span>
         <label style="margin: 0 5px 0 15px; width: 25px;">URL</label>
-        <input id="request-url" name="request-url" type="url" autocomplete="on" style="margin: 0 auto; width: -moz-calc(100% - 385px);" placeholder="http://www.example.com"><span style="width:45px; padding: 4px; margin: 0 0 0 -2px" class="request-url-icons"><i class="favorite-icon icon-star-empty"></i><span class="dropdown">
+        <input id="request-url" name="request-url" type="url" autocomplete="on" style="margin: 0 auto; width: calc(100% - 385px);" placeholder="http://www.example.com"><span style="width:45px; padding: 4px; margin: 0 0 0 -2px" class="request-url-icons"><i class="favorite-icon icon-star-empty"></i><span class="dropdown">
           <a class="dropdown-toggle" data-toggle="dropdown" href="#"><i class="favorite-list-icon icon-chevron-down"></i></a>
           <ul id="request-url-list" class="dropdown-menu">
           </ul>


### PR DESCRIPTION
In version 53 Firefox dropped support for the non-standard prefixed `-moz-calc()`.
Support for unprefixed `calc()` has been there since version 16 - https://developer.mozilla.org/en/docs/Web/CSS/calc
And since this add-on minVersion is 22 it is safe to replace `-moz-calc()` with `calc()`.
This will improve the add-on compatibility with Firefox 53+.