### PR TITLE
fix content-type header for client credentials Oauth2 Authentication

### DIFF
--- a/src/scripts/cores/oauth2.js
+++ b/src/scripts/cores/oauth2.js
@@ -455,7 +455,7 @@ $(function () {
         data['scope'] = params.scope;
       }
       ajaxOption['data'] = data;
-      ajaxOption['contentType'] = 'Content-Type: application/x-www-form-urlencoded';
+      ajaxOption['contentType'] = 'application/x-www-form-urlencoded';
     }
     console.log(`[oauth2.js][obtain-access-token] ajaxOption`, ajaxOption);
     


### PR DESCRIPTION
When getting an OAuth2 token with client credentials, the "Content-Type" header is malformed which in my case causes the authentication server to error with HTTP code 400:

![Screenshot from 2020-09-22 16-10-25](https://user-images.githubusercontent.com/11944422/93893899-7135f900-fcee-11ea-8db6-b3de229f53f2.png)
